### PR TITLE
feat: 버튼 컴포넌트 추가 - #23

### DIFF
--- a/src/components/button/Button.tsx
+++ b/src/components/button/Button.tsx
@@ -1,0 +1,89 @@
+import type { ReactNode } from 'react';
+import {
+  type ButtonStyle,
+  FILTER,
+  type FilterSize,
+  type FilterState,
+  LABEL,
+  type LabelSize,
+  type LabelState,
+  PRIMARY,
+  type PrimarySize,
+  type PrimaryState,
+  SECONDARY,
+  type SecondarySize,
+  type SecondaryState,
+} from '@/components/button/type';
+
+interface BaseProps {
+  width: number;
+  height: number;
+  children?: ReactNode;
+  onClick: () => void;
+}
+
+type ButtonProps =
+  | ({ variant: 'primary'; size: PrimarySize; state: PrimaryState } & BaseProps)
+  | ({
+      variant: 'secondary';
+      size: SecondarySize;
+      state: SecondaryState;
+    } & BaseProps)
+  | ({ variant: 'label'; size: LabelSize; state: LabelState } & BaseProps)
+  | ({ variant: 'filter'; size: FilterSize; state: FilterState } & BaseProps);
+
+function styleFromProps(p: ButtonProps): ButtonStyle {
+  switch (p.variant) {
+    case 'primary': {
+      return PRIMARY[p.size][p.state];
+    }
+    case 'secondary': {
+      return SECONDARY[p.size][p.state];
+    }
+    case 'label': {
+      return LABEL[p.size][p.state];
+    }
+    case 'filter': {
+      return FILTER[p.size][p.state];
+    }
+  }
+}
+
+function buildClassName(style: ButtonStyle): string {
+  const base =
+    'inline-flex items-center justify-center text-center select-none gap-1';
+
+  return [
+    base,
+    style.bg,
+    style.text,
+    style.textSize,
+    style.radius,
+    style.stroke,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+export default function Button(props: ButtonProps) {
+  const { variant, state, width, height, children, onClick } = props;
+
+  const style = styleFromProps(props);
+
+  const className = buildClassName(style);
+
+  const isDisabled =
+    (variant === 'primary' && state === 'disable') ||
+    (variant === 'secondary' && state === 'disable');
+
+  return (
+    <button
+      className={className}
+      style={{ width, height }}
+      disabled={isDisabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/button/type.ts
+++ b/src/components/button/type.ts
@@ -1,0 +1,277 @@
+export type PrimarySize = 'lg' | 'md' | 'sm';
+export type PrimaryState = 'active' | 'disable';
+
+export type SecondarySize = 'lg' | 'md' | 'sm';
+export type SecondaryState = 'normal' | 'active' | 'disable';
+
+export type LabelSize = 'lg' | 'md' | 'sm';
+export type LabelState = 'normal' | 'active';
+
+export type FilterSize = 'PC' | 'mobile';
+// export type FilterSize = 'lg' | 'sm';
+export type FilterState = 'active' | 'normal';
+
+export interface ButtonStyle {
+  bg?: string | null;
+  text: string;
+  textSize: string;
+  radius: string;
+  stroke?: string | null;
+  labelSize?: number | null;
+}
+
+/* sonarjs/no-duplicate-string은 3번 이상 반복되는 문자열 리터럴을 감지 */
+const BG_PRIMARY_100 = 'bg-primary-100';
+const BG_PRIMARY_500 = 'bg-primary-500';
+const BG_WHITE = 'bg-white';
+const BG_DISABLED = 'bg-gray-200';
+const BG_333333 = 'bg-[#333333]';
+const TEXT_WHITE = 'text-white';
+const TEXT_GRAY_50 = 'text-gray-50';
+const TEXT_GRAY_200 = 'text-gray-200';
+const TEXT_GRAY_600 = 'text-gray-600';
+const TEXT_GRAY_950 = 'text-gray-950';
+const TEXT_16 = 'text-16';
+const TEXT_14 = 'text-14';
+const TEXT_B = 'font-bold';
+const TEXT_M = 'font-medium';
+const BORDER_GRAY_200 = 'border border-gray-200';
+const BORDER_D8D8D8 = 'border border-[#D8D8D8]';
+const RADIUS_LARGE = 'rounded-2xl';
+const RADIUS_MEDIUM = 'rounded-[14px]';
+const RADIUS_SMALL = 'rounded-xl';
+const RADIUS_100 = 'rounded-[100px]';
+const LABEL_LARGE = 24;
+const LABEL_MEDIUM = 20;
+const LABEL_SMALL = 16;
+
+export const PRIMARY: Record<PrimarySize, Record<PrimaryState, ButtonStyle>> = {
+  lg: {
+    active: {
+      bg: BG_PRIMARY_500,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_16} ${TEXT_B}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+    },
+    disable: {
+      bg: BG_DISABLED,
+      text: TEXT_GRAY_50,
+      textSize: `${TEXT_16} ${TEXT_B}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+    },
+  },
+  md: {
+    active: {
+      bg: BG_PRIMARY_500,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_16} ${TEXT_B}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+    },
+    disable: {
+      bg: BG_DISABLED,
+      text: TEXT_GRAY_50,
+      textSize: `${TEXT_16} ${TEXT_B}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+    },
+  },
+  sm: {
+    active: {
+      bg: BG_PRIMARY_500,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_14} ${TEXT_B}`,
+      radius: RADIUS_MEDIUM,
+      stroke: null,
+    },
+    disable: {
+      bg: BG_DISABLED,
+      text: TEXT_GRAY_50,
+      textSize: `${TEXT_14} ${TEXT_B}`,
+      radius: RADIUS_MEDIUM,
+      stroke: null,
+    },
+  },
+};
+
+export const SECONDARY: Record<
+  SecondarySize,
+  Record<SecondaryState, ButtonStyle>
+> = {
+  lg: {
+    normal: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_600,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_LARGE,
+      stroke: BORDER_GRAY_200,
+      labelSize: LABEL_LARGE,
+    },
+    active: {
+      bg: BG_PRIMARY_500,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+      labelSize: LABEL_LARGE,
+    },
+    disable: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_200,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_LARGE,
+      stroke: BORDER_GRAY_200,
+      labelSize: LABEL_LARGE,
+    },
+  },
+  md: {
+    normal: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_600,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_MEDIUM,
+      stroke: BORDER_GRAY_200,
+      labelSize: LABEL_MEDIUM,
+    },
+    active: {
+      bg: BG_PRIMARY_500,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_MEDIUM,
+      stroke: null,
+      labelSize: LABEL_MEDIUM,
+    },
+    disable: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_200,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_MEDIUM,
+      stroke: BORDER_GRAY_200,
+      labelSize: LABEL_MEDIUM,
+    },
+  },
+  sm: {
+    normal: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_600,
+      textSize: `${TEXT_14} ${TEXT_M}`,
+      radius: RADIUS_SMALL,
+      stroke: BORDER_GRAY_200,
+      labelSize: LABEL_SMALL,
+    },
+    active: {
+      bg: BG_PRIMARY_500,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_14} ${TEXT_M}`,
+      radius: RADIUS_SMALL,
+      stroke: null,
+      labelSize: LABEL_SMALL,
+    },
+    disable: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_200,
+      textSize: `${TEXT_14} ${TEXT_M}`,
+      radius: RADIUS_SMALL,
+      stroke: BORDER_GRAY_200,
+      labelSize: LABEL_SMALL,
+    },
+  },
+};
+
+export const LABEL: Record<LabelSize, Record<LabelState, ButtonStyle>> = {
+  lg: {
+    active: {
+      bg: BG_PRIMARY_100,
+      text: TEXT_GRAY_950,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+      labelSize: LABEL_LARGE,
+    },
+    normal: {
+      bg: null,
+      text: TEXT_GRAY_600,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_LARGE,
+      stroke: null,
+      labelSize: LABEL_LARGE,
+    },
+  },
+  md: {
+    active: {
+      bg: BG_PRIMARY_100,
+      text: TEXT_GRAY_950,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_MEDIUM,
+      stroke: null,
+      labelSize: LABEL_MEDIUM,
+    },
+    normal: {
+      bg: null,
+      text: TEXT_GRAY_600,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_MEDIUM,
+      stroke: null,
+      labelSize: LABEL_MEDIUM,
+    },
+  },
+  sm: {
+    active: {
+      bg: BG_PRIMARY_100,
+      text: TEXT_GRAY_950,
+      textSize: `${TEXT_14} ${TEXT_M}`,
+      radius: RADIUS_SMALL,
+      stroke: null,
+      labelSize: LABEL_SMALL,
+    },
+    normal: {
+      bg: null,
+      text: TEXT_GRAY_600,
+      textSize: `${TEXT_14} ${TEXT_M}`,
+      radius: RADIUS_SMALL,
+      stroke: null,
+      labelSize: LABEL_SMALL,
+    },
+  },
+};
+
+export const FILTER: Record<FilterSize, Record<FilterState, ButtonStyle>> = {
+  PC: {
+    active: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_950,
+      textSize: `${TEXT_16} ${TEXT_M}`,
+      radius: RADIUS_100,
+      stroke: BORDER_D8D8D8,
+      labelSize: LABEL_LARGE,
+    },
+    normal: {
+      bg: BG_333333,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_16} ${TEXT_B}`,
+      radius: RADIUS_100,
+      stroke: null,
+      labelSize: LABEL_LARGE,
+    },
+  },
+  mobile: {
+    active: {
+      bg: BG_WHITE,
+      text: TEXT_GRAY_950,
+      textSize: `${TEXT_14} ${TEXT_M}`,
+      radius: RADIUS_100,
+      stroke: BORDER_D8D8D8,
+      labelSize: LABEL_SMALL,
+    },
+    normal: {
+      bg: BG_333333,
+      text: TEXT_WHITE,
+      textSize: `${TEXT_14} ${TEXT_B}`,
+      radius: RADIUS_100,
+      stroke: null,
+      labelSize: LABEL_SMALL,
+    },
+  },
+};


### PR DESCRIPTION
# 버튼 컴포넌트 추가
## 첨부 요소
- variant: 버튼 타입
- size: 버튼 내부 요소 사이즈
- width: 버튼 너비
- height: 버튼 높이
- state: 버튼 상태

<img width="755" height="567" alt="image" src="https://github.com/user-attachments/assets/dac82e6f-f675-4a6e-9e7f-fc2fe4c6a410" />

사용 예시
```tsx
<Button
  variant='primary'
  size='lg'
  width={240}
  height={40}
  state='active'
  onClick={() => {
    console.log('Button');
  }}
>
  <Image src={Google} alt='구글로고' />
  <div>버튼</div>
</Button>
```

이미지 삽입 시의 크기 조절이 아직 불가합니다.
