### PR TITLE
feat: input 컴포넌트 UI 추가

### DIFF
--- a/src/app/test/calendarBadge/page.tsx
+++ b/src/app/test/calendarBadge/page.tsx
@@ -2,54 +2,50 @@ import CalendarBadge from '@/components/calendarBadge/CalendarBadge';
 import type { BadgeType } from '@/components/calendarBadge/type';
 
 // 테스트 데이터
-const badgeTestData: { type: BadgeType; count: number }[] = [
-  { type: 'reservation', count: 1 },
-  { type: 'approval', count: 5 },
-  { type: 'completed', count: 12 },
-  { type: 'reservation', count: 0 }, // 카운트 0 테스트
+const badgeTestData: { type: BadgeType, count: number }[] = [
+    { type: 'reservation', count: 1 },
+    { type: 'approval', count: 5 },
+    { type: 'completed', count: 12 },
+    { type: 'reservation', count: 0 }, // 카운트 0 테스트
 ];
 
 export default function BadgeTestPage() {
-  return (
-    // 뱃지 디자인을 명확하게 확인하기 위해 흰색 배경과 적당한 패딩을 줍니다.
-    <div className='min-h-screen bg-white p-10'>
-      <h1 className='mb-8 text-3xl font-bold text-gray-800'>
-        뱃지 컴포넌트 테스트
-      </h1>
-      <p className='mb-6 text-gray-600'></p>
-
-      <div className='flex flex-col space-y-4'>
-        {badgeTestData.map((data) => {
-          // 0인 뱃지는 렌더링하지 않도록 조건부 처리 (선택 사항)
-          return data.count > 0 ? (
-            <div
-              key={`${data.type}-${data.count}`}
-              className='flex items-center space-x-4'
-            >
-              <span className='w-24 font-medium text-gray-700'>
-                {data.type.toUpperCase()} ({data.count})
-              </span>
-              <CalendarBadge type={data.type} count={data.count} />
-            </div>
-          ) : (
-            <p key={`${data.type}-zero`} className='text-gray-400'>
-              {data.type.toUpperCase()} 뱃지는 카운트가 0이라 표시되지 않음.
+    return (
+        // 뱃지 디자인을 명확하게 확인하기 위해 흰색 배경과 적당한 패딩을 줍니다.
+        <div className="min-h-screen bg-white p-10">
+            <h1 className="text-3xl font-bold mb-8 text-gray-800">
+                뱃지 컴포넌트 테스트
+            </h1>
+            <p className="mb-6 text-gray-600">
             </p>
-          );
-        })}
 
-        {/* 추가적으로 여러 개를 나란히 배치하는 경우 */}
-        <div className='pt-8'>
-          <h2 className='mb-4 text-xl font-semibold text-gray-800'>
-            날짜 셀 테스트 (나란히 배치)
-          </h2>
-          <div className='flex flex-wrap gap-2'>
-            <CalendarBadge type='reservation' count={3} />
-            <CalendarBadge type='approval' count={1} />
-            <CalendarBadge type='completed' count={5} />
-          </div>
+            <div className="flex flex-col space-y-4">
+                {badgeTestData.map((data) => {
+                    // 0인 뱃지는 렌더링하지 않도록 조건부 처리 (선택 사항)
+                    return data.count > 0 ? (
+                        <div key={`${data.type}-${data.count}`} className="flex items-center space-x-4">
+                            <span className="w-24 text-gray-700 font-medium">
+                                {data.type.toUpperCase()} ({data.count})
+                            </span>
+                            <CalendarBadge type={data.type} count={data.count} />
+                        </div>
+                    ) : (
+                        <p key={`${data.type}-zero`} className="text-gray-400">
+                            {data.type.toUpperCase()} 뱃지는 카운트가 0이라 표시되지 않음.
+                        </p>
+                    );
+                })}
+
+                {/* 추가적으로 여러 개를 나란히 배치하는 경우 */}
+                <div className="pt-8">
+                    <h2 className="text-xl font-semibold mb-4 text-gray-800">날짜 셀 테스트 (나란히 배치)</h2>
+                    <div className="flex flex-wrap gap-2">
+                        <CalendarBadge type="reservation" count={3} />
+                        <CalendarBadge type="approval" count={1} />
+                        <CalendarBadge type="completed" count={5} />
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
### Input 컴포넌트
---
#### Props
- label: 입력 필드 라벨
- placeholder: placeholder 텍스트
- type: 입력 타입 (text, email, password)
- value: 입력값
- onChange: 값 변경 핸들러
- error: 에러 메시지
- c- lassName: 너비 조정용 클래스

#### 기능
- 텍스트/이메일/비밀번호 타입
- 비밀번호 가시성 토글 (눈 아이콘 클릭)
- 포커스 상태에 따른 테두리 색상 변경
- 에러 상태. 메시지 표시

#### 사용 예시
```
<Input
  label='이메일'
  type='email'
  placeholder='이메일을 입력해주세요'
  value={email}
  onChange={(value) => setEmail(value)}
  error='올바른 이메일을 입력해주세요'
  className='w-[400px]'
/>
```
<img width="375" height="209" alt="20251008_091632" src="https://github.com/user-attachments/assets/9fea39d0-bc07-4e87-963b-06429f9a3c34" />
<img width="393" height="232" alt="dddddd" src="https://github.com/user-attachments/assets/1cc0a46f-2b42-4f78-be53-d9690b076d82" />

