### PR TITLE
feat: sideMenu 컴포넌트 UI 추가

### DIFF
--- a/src/app/test/calendarBadge/page.tsx
+++ b/src/app/test/calendarBadge/page.tsx
@@ -2,54 +2,50 @@ import CalendarBadge from '@/components/calendarBadge/CalendarBadge';
 import type { BadgeType } from '@/components/calendarBadge/type';
 
 // 테스트 데이터
-const badgeTestData: { type: BadgeType; count: number }[] = [
-  { type: 'reservation', count: 1 },
-  { type: 'approval', count: 5 },
-  { type: 'completed', count: 12 },
-  { type: 'reservation', count: 0 }, // 카운트 0 테스트
+const badgeTestData: { type: BadgeType, count: number }[] = [
+    { type: 'reservation', count: 1 },
+    { type: 'approval', count: 5 },
+    { type: 'completed', count: 12 },
+    { type: 'reservation', count: 0 }, // 카운트 0 테스트
 ];
 
 export default function BadgeTestPage() {
-  return (
-    // 뱃지 디자인을 명확하게 확인하기 위해 흰색 배경과 적당한 패딩을 줍니다.
-    <div className='min-h-screen bg-white p-10'>
-      <h1 className='mb-8 text-3xl font-bold text-gray-800'>
-        뱃지 컴포넌트 테스트
-      </h1>
-      <p className='mb-6 text-gray-600'></p>
-
-      <div className='flex flex-col space-y-4'>
-        {badgeTestData.map((data) => {
-          // 0인 뱃지는 렌더링하지 않도록 조건부 처리 (선택 사항)
-          return data.count > 0 ? (
-            <div
-              key={`${data.type}-${data.count}`}
-              className='flex items-center space-x-4'
-            >
-              <span className='w-24 font-medium text-gray-700'>
-                {data.type.toUpperCase()} ({data.count})
-              </span>
-              <CalendarBadge type={data.type} count={data.count} />
-            </div>
-          ) : (
-            <p key={`${data.type}-zero`} className='text-gray-400'>
-              {data.type.toUpperCase()} 뱃지는 카운트가 0이라 표시되지 않음.
+    return (
+        // 뱃지 디자인을 명확하게 확인하기 위해 흰색 배경과 적당한 패딩을 줍니다.
+        <div className="min-h-screen bg-white p-10">
+            <h1 className="text-3xl font-bold mb-8 text-gray-800">
+                뱃지 컴포넌트 테스트
+            </h1>
+            <p className="mb-6 text-gray-600">
             </p>
-          );
-        })}
 
-        {/* 추가적으로 여러 개를 나란히 배치하는 경우 */}
-        <div className='pt-8'>
-          <h2 className='mb-4 text-xl font-semibold text-gray-800'>
-            날짜 셀 테스트 (나란히 배치)
-          </h2>
-          <div className='flex flex-wrap gap-2'>
-            <CalendarBadge type='reservation' count={3} />
-            <CalendarBadge type='approval' count={1} />
-            <CalendarBadge type='completed' count={5} />
-          </div>
+            <div className="flex flex-col space-y-4">
+                {badgeTestData.map((data) => {
+                    // 0인 뱃지는 렌더링하지 않도록 조건부 처리 (선택 사항)
+                    return data.count > 0 ? (
+                        <div key={`${data.type}-${data.count}`} className="flex items-center space-x-4">
+                            <span className="w-24 text-gray-700 font-medium">
+                                {data.type.toUpperCase()} ({data.count})
+                            </span>
+                            <CalendarBadge type={data.type} count={data.count} />
+                        </div>
+                    ) : (
+                        <p key={`${data.type}-zero`} className="text-gray-400">
+                            {data.type.toUpperCase()} 뱃지는 카운트가 0이라 표시되지 않음.
+                        </p>
+                    );
+                })}
+
+                {/* 추가적으로 여러 개를 나란히 배치하는 경우 */}
+                <div className="pt-8">
+                    <h2 className="text-xl font-semibold mb-4 text-gray-800">날짜 셀 테스트 (나란히 배치)</h2>
+                    <div className="flex flex-wrap gap-2">
+                        <CalendarBadge type="reservation" count={3} />
+                        <CalendarBadge type="approval" count={1} />
+                        <CalendarBadge type="completed" count={5} />
+                    </div>
+                </div>
+            </div>
         </div>
-      </div>
-    </div>
-  );
+    );
 }


### PR DESCRIPTION
### SideMenu 컴포넌트
---
#### Props
- size: 메뉴 크기 (large, small)
- className: 추가 스타일 클래스 (optional)

#### 기능
- 프로필 영역 표시 (프로필 이미지 + 편집 아이콘)
- 4가지 메뉴 항목 제공
  - 내 정보
  - 예약내역
  - 내 체험 관리
  - 예약 현황
- 활성 메뉴, 호버(마우스오버) 메뉴 배경색 변경
- 두 가지 크기 지원(Large, Small)

#### 사용 예시
```
<SideMenu size='large' />
<SideMenu size='small' className='mt-4' />
```
<img width="541" height="506" alt="20251008_092613" src="https://github.com/user-attachments/assets/cdb959f7-360b-468b-8f48-05b5d0cae03e" />
