### PR TITLE
fix: StateBadge 타입명 수정

### DIFF
--- a/src/app/test/stateBadge/page.tsx
+++ b/src/app/test/stateBadge/page.tsx
@@ -24,11 +24,11 @@ export default function StateBadgeTestPage() {
           StateBadge 컴포넌트
         </h2>
         <div className='flex flex-wrap gap-2'>
-          <StateBadge state='cancelled' />
-          <StateBadge state='rejected' />
+          <StateBadge state='canceled' />
+          <StateBadge state='pending' />
+          <StateBadge state='declined' />
           <StateBadge state='completed' />
-          <StateBadge state='experience_completed' />
-          <StateBadge state='approved' />
+          <StateBadge state='confirmed' />
         </div>
       </div>
 
@@ -65,14 +65,18 @@ export default function StateBadgeTestPage() {
             type='email'
             value={emailValue}
             error={emailError}
-            onChange={setEmailValue}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setEmailValue(e.target.value);
+            }}
           />
           <Input
             label='비밀번호'
             placeholder='비밀번호를 입력해 주세요'
             type='password'
             value={passwordValue}
-            onChange={setPasswordValue}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              setPasswordValue(e.target.value);
+            }}
           />
         </div>
       </div>
@@ -102,7 +106,7 @@ export default function StateBadgeTestPage() {
             }}
           />
           <CardList
-            state='cancelled'
+            state='canceled'
             title='내 강아지 사진 찍어주기'
             date='2023.02.11'
             startTime='13:00'
@@ -120,7 +124,7 @@ export default function StateBadgeTestPage() {
             }}
           />
           <CardList
-            state='experience_completed'
+            state='completed'
             title='열기구 페스티벌'
             date='2025.08.28'
             startTime='11:00'

--- a/src/components/stateBadge/StateBadge.tsx
+++ b/src/components/stateBadge/StateBadge.tsx
@@ -1,26 +1,27 @@
 import type {
   StateBadgeProps,
   StateConfig,
+  StateType,
 } from '@/components/stateBadge/type';
 
-const STATE_CONFIG = {
-  cancelled: {
+const STATE_CONFIG: Record<StateType, StateConfig> = {
+  canceled: {
     text: '예약 취소',
     className: 'bg-gray-100 text-gray-600',
   },
-  completed: {
+  pending: {
     text: '예약 완료',
     style: { backgroundColor: '#E9FBE4', color: '#2BA90D' },
   },
-  rejected: {
+  declined: {
     text: '예약 거절',
     style: { backgroundColor: '#FCECEA', color: '#F96767' },
   },
-  experience_completed: {
+  completed: {
     text: '체험 완료',
     style: { backgroundColor: '#DAF0FF', color: '#0D6CD1' },
   },
-  approved: {
+  confirmed: {
     text: '예약 승인',
     style: { backgroundColor: '#DDF9F9', color: '#1790A0' },
   },
@@ -31,8 +32,8 @@ export default function StateBadge({ state, className = '' }: StateBadgeProps) {
 
   return (
     <span
-      className={`inline-flex items-center justify-center rounded-full px-3 py-1.5 text-sm font-bold ${'className' in stateConfig ? stateConfig.className : ''} ${className}`}
-      style={'style' in stateConfig ? stateConfig.style : undefined}
+      className={`inline-flex items-center justify-center rounded-full px-3 py-1.5 text-sm font-bold ${stateConfig.className || ''} ${className}`}
+      style={stateConfig.style || undefined}
     >
       {stateConfig.text}
     </span>

--- a/src/components/stateBadge/type.ts
+++ b/src/components/stateBadge/type.ts
@@ -1,9 +1,9 @@
 export type StateType =
-  | 'cancelled'
-  | 'completed'
-  | 'rejected'
-  | 'experience_completed'
-  | 'approved';
+  | 'pending'
+  | 'confirmed'
+  | 'declined'
+  | 'canceled'
+  | 'completed';
 
 export interface StateConfig {
   text: string;


### PR DESCRIPTION
StateBadge의 타입명을 swagger 명세에 맞게 수정
- pending: { text: '예약 완료' }
- confirmed: { text: '예약 승인' }
- declined: { text: '예약 거절' }
- canceled: { text: '예약 취소' }
- completed: { text: '체험 완료' }