### PR TITLE
feat: 내 체험 관리 페이지 내 실제 데이터 랜더링

### DIFF
--- a/src/app/(with-header)/(with-sidebar)/myactivities/page.tsx
+++ b/src/app/(with-header)/(with-sidebar)/myactivities/page.tsx
@@ -1,20 +1,19 @@
-'use client';
-
 import Image from 'next/image';
+import { apiFetch } from '@/api/api';
 import Button from '@/components/button/Button';
 import ActivitiyCard from '@/domain/myactivities/components/ActivityCard';
+import RegisterActivity from '@/domain/myactivities/components/RegitsterActivity';
 import type { Activity, MyActivities } from '@/domain/myactivities/type';
-import mockData from '@/mocks/mockMyActivities2.json'; // 🗄️ 목 데이터
+// import mockData from '@/mocks/mockMyActivities.json'; // 🗄️ 목 데이터
 
-export default function Page() {
+export default async function Page() {
   // 🗄️ 목 데이터
-  const { activities, totalCount } = mockData as MyActivities;
+  // const { activities, totalCount } = mockData as MyActivities;
+
+  const { activities, totalCount } =
+    await apiFetch<MyActivities>('/my-activities');
 
   const hasActivities = Boolean(totalCount);
-
-  const handleClick = () => {
-    console.log('clicked');
-  };
 
   return (
     <main className='w-full'>
@@ -29,13 +28,7 @@ export default function Page() {
             </p>
           </div>
           <div className='hidden sm:block'>
-            <Button
-              variant='primary'
-              classNames='w-[138px]'
-              onClick={handleClick}
-            >
-              체험 등록하기
-            </Button>
+            <RegisterActivity />
           </div>
         </div>
         <div className='scrollbar-hide flex h-full flex-col gap-6 overflow-y-auto'>

--- a/src/domain/myactivities/components/ActivityCard.tsx
+++ b/src/domain/myactivities/components/ActivityCard.tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import starIcon from '@/domain/myactivities/assets/icon_star.svg';
 import type { ActivityCardProps } from '@/domain/myactivities/components/type';
 
 export default function ActivityCard({
@@ -12,42 +11,144 @@ export default function ActivityCard({
   const formattedPrice = `₩${price.toLocaleString()}`;
 
   return (
-    <div className='flex h-[202px] w-[640px] items-center justify-between rounded-3xl px-7.5 shadow-[0_4px_24px_rgba(156,180,202,0.2)]'>
-      <div>
-        <h2 className='text-16 md:text-18 mb-1.5 font-bold text-gray-950 md:mb-2'>
-          {title}
-        </h2>
-        <div className='mb-2.5 flex items-center gap-0.5 md:mb-3'>
-          <div className='relative h-[14px] w-[14px] md:h-[16px] md:w-[16px]'>
-            <Image fill src={starIcon} alt='별점' className='object-cover' />
+    <div>
+      {/* sm 기준 */}
+      <div className='relative flex sm:hidden'>
+        <div className='flex h-[178px] w-[327px] justify-between rounded-3xl p-6 shadow-[0_4px_24px_rgba(156,180,202,0.2)]'>
+          <div className='flex flex-col justify-between'>
+            <h2 className='text-16 mb-1.5 flex items-center leading-[19px] font-bold text-gray-950'>
+              {title}
+            </h2>
+            <div className='mb-2.5 flex items-center gap-0.5'>
+              <div className='relative h-[14px] w-[14px]'>
+                <Image
+                  fill
+                  src='/icons/star.svg'
+                  alt='별점'
+                  className='object-cover'
+                />
+              </div>
+              <div className='text-13 flex gap-0.5 leading-[16px] text-gray-500'>
+                <p>{rating}</p>
+                <p>({reviewCount})</p>
+              </div>
+            </div>
+            <div className='mb-3 flex items-center gap-1'>
+              <p className='text-16 leading-[19px] font-bold text-gray-950'>
+                {formattedPrice}
+              </p>
+              <p className='text-14 font-medium text-gray-400'>/ 인</p>
+            </div>
+            <div className='flex gap-2'>
+              <button className='text-14 h-[29px] w-[68px] rounded-lg border border-gray-50 font-medium text-gray-600'>
+                수정하기
+              </button>
+              <button className='text-14 h-[29px] w-[68px] rounded-lg bg-gray-50 font-medium text-gray-600'>
+                삭제하기
+              </button>
+            </div>
           </div>
-          <div className='text-13 md:text-16 flex gap-0.5 text-gray-500'>
-            <p>{rating}</p>
-            <p>({reviewCount})</p>
+          <div className='relative h-[82px] w-[82px]'>
+            <Image
+              fill
+              className='rounded-[20px] object-cover'
+              src={bannerImageUrl}
+              alt={title}
+            />
           </div>
-        </div>
-        <div className='mb-3 flex items-center gap-1 md:mb-5'>
-          <p className='text-16 md:text-18 font-bold text-gray-950'>
-            {formattedPrice}
-          </p>
-          <p className='text-14 md:text-16 font-medium text-gray-400'>/ 인</p>
-        </div>
-        <div className='flex gap-2'>
-          <button className='text-14 h-[29px] w-[68px] rounded-lg border border-gray-50 font-medium text-gray-600'>
-            수정하기
-          </button>
-          <button className='text-14 h-[29px] w-[68px] rounded-lg bg-gray-50 font-medium text-gray-600'>
-            삭제하기
-          </button>
         </div>
       </div>
-      <div className='relative h-[82px] w-[82px] md:h-[142px] md:w-[142px]'>
-        <Image
-          fill
-          className='rounded-[20px] object-cover md:rounded-4xl'
-          src={bannerImageUrl}
-          alt={title}
-        />
+
+      {/* md 기준 */}
+      <div className='hidden sm:flex md:hidden'>
+        <div className='flex h-[159px] w-[476px] justify-between rounded-3xl p-6 leading-none shadow-[0_4px_24px_rgba(156,180,202,0.2)]'>
+          <div>
+            <h2 className='text-16 mb-1.5 leading-[19px] font-bold text-gray-950'>
+              {title}
+            </h2>
+            <div className='mb-2.5 flex items-center gap-0.5'>
+              <div className='relative h-[14px] w-[14px]'>
+                <Image
+                  fill
+                  src='/icons/star.svg'
+                  alt='별점'
+                  className='object-cover'
+                />
+              </div>
+              <div className='text-13 flex gap-0.5 leading-[16px] text-gray-500'>
+                <p>{rating}</p>
+                <p>({reviewCount})</p>
+              </div>
+            </div>
+            <div className='mb-3 flex items-center gap-1'>
+              <p className='text-16 leading-[19px] font-bold text-gray-950'>
+                {formattedPrice}
+              </p>
+              <p className='text-14 font-medium text-gray-400'>/ 인</p>
+            </div>
+            <div className='flex gap-2'>
+              <button className='text-14 h-[29px] w-[68px] rounded-lg border border-gray-50 font-medium text-gray-600'>
+                수정하기
+              </button>
+              <button className='text-14 h-[29px] w-[68px] rounded-lg bg-gray-50 font-medium text-gray-600'>
+                삭제하기
+              </button>
+            </div>
+          </div>
+          <div className='relative flex h-[82px] w-[82px]'>
+            <Image
+              fill
+              className='rounded-[20px] object-cover md:rounded-4xl'
+              src={bannerImageUrl}
+              alt={title}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* lg 기준 */}
+      <div className='hidden md:flex'>
+        <div className='flex h-[202px] w-[640px] items-center justify-between rounded-3xl px-7.5 shadow-[0_4px_24px_rgba(156,180,202,0.2)]'>
+          <div>
+            <h2 className='text-18 mb-2 font-bold text-gray-950'>{title}</h2>
+            <div className='mb-3 flex items-center gap-0.5'>
+              <div className='relative h-[16px] w-[16px]'>
+                <Image
+                  fill
+                  src='/icons/star.svg'
+                  alt='별점'
+                  className='object-cover'
+                />
+              </div>
+              <div className='text-16 flex gap-0.5 font-medium text-gray-500'>
+                <p>{rating}</p>
+                <p>({reviewCount})</p>
+              </div>
+            </div>
+            <div className='mb-5 flex items-center gap-1'>
+              <p className='text-18 font-bold text-gray-950'>
+                {formattedPrice}
+              </p>
+              <p className='text-16 font-medium text-gray-400'>/ 인</p>
+            </div>
+            <div className='flex gap-2'>
+              <button className='text-14 h-[29px] w-[68px] rounded-lg border border-gray-50 font-medium text-gray-600'>
+                수정하기
+              </button>
+              <button className='text-14 h-[29px] w-[68px] rounded-lg bg-gray-50 font-medium text-gray-600'>
+                삭제하기
+              </button>
+            </div>
+          </div>
+          <div className='relative h-[142px] w-[142px]'>
+            <Image
+              fill
+              className='rounded-4xl object-cover'
+              src={bannerImageUrl}
+              alt={title}
+            />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/domain/myactivities/components/RegitsterActivity.tsx
+++ b/src/domain/myactivities/components/RegitsterActivity.tsx
@@ -1,0 +1,14 @@
+'use client';
+import Button from '@/components/button/Button';
+
+export default function RegisterActivity() {
+  const handleClick = () => {
+    console.log('clicked');
+  };
+
+  return (
+    <Button variant='primary' classNames='w-[138px]' onClick={handleClick}>
+      체험 등록하기
+    </Button>
+  );
+}


### PR DESCRIPTION
## 수정 파일
```
src/app/(with-header)/(with-sidebar)/myactivities/page.tsx
src/domain/myactivities/components/ActivityCard.tsx
src/domain/myactivities/components/RegitsterActivity.tsx
```
## 적용 화면
<img width="1512" height="858" alt="스크린샷 2025-10-18 오후 8 59 51" src="https://github.com/user-attachments/assets/6e71b5c6-663d-4f83-836d-e0829899166f" />
