### PR TITLE
feat: 사이드메뉴 페이지 연동

### DIFF
--- a/src/app/(with-header)/(with-sidebar)/layout.tsx
+++ b/src/app/(with-header)/(with-sidebar)/layout.tsx
@@ -6,7 +6,7 @@ export default function SettingLayout({ children }: { children: ReactNode }) {
     <div className='mx-auto flex max-w-[1200px] justify-center gap-8 px-4 py-8 md:px-12'>
       {/* 왼쪽: SideMenu (태블릿 이상에서만 표시) */}
       <aside className='hidden md:block'>
-        <SideMenu size='large' activeItem='reservationStatus' />
+        <SideMenu size='large' />
       </aside>
       {children}
     </div>

--- a/src/app/(with-header)/reservation-status/page.tsx
+++ b/src/app/(with-header)/reservation-status/page.tsx
@@ -204,7 +204,7 @@ export default function ReservationStatusPage() {
     <div className='mx-auto flex max-w-[1200px] gap-4 px-4 py-4 sm:gap-6 sm:px-6 sm:py-6 md:gap-8 md:px-12 md:py-8'>
       {/* 왼쪽: SideMenu (모바일에서만 숨김) */}
       <aside className='hidden md:block lg:w-auto'>
-        <SideMenu size='large' activeItem='reservationStatus' />
+        <SideMenu size='large' />
       </aside>
 
       {/* 오른쪽: 메인 콘텐츠 */}

--- a/src/components/side-menu/index.tsx
+++ b/src/components/side-menu/index.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { usePathname, useRouter } from 'next/navigation';
 import { useState } from 'react';
 import ProfileImageUploader from '@/components/side-menu/ProfileImageUploader';
 import type {
@@ -14,21 +15,25 @@ const MENU_ITEMS: MenuItem[] = [
     id: 'myInfo',
     label: '내 정보',
     iconPath: '/icons/icon_user.svg',
+    href: '/profile',
   },
   {
     id: 'reservationHistory',
     label: '예약내역',
     iconPath: '/icons/icon_list.svg',
+    href: '/myreservation',
   },
   {
     id: 'manageExperiences',
     label: '내 체험 관리',
     iconPath: '/icons/icon_setting.svg',
+    href: '/myactivities',
   },
   {
     id: 'reservationStatus',
     label: '예약 현황',
     iconPath: '/icons/icon_calendar.svg',
+    href: '/reservation-status',
   },
 ];
 
@@ -63,18 +68,45 @@ const PRIMARY_FILTER =
 export default function SideMenu({
   size,
   className = '',
-  activeItem: initialActiveItem = 'reservationHistory',
 }: SideMenuProps) {
   const config = SIZE_CONFIG[size];
-  const [activeItem, setActiveItem] = useState<MenuItemType>(initialActiveItem);
+  const router = useRouter();
+  const pathname = usePathname();
 
-  const handleMenuClick = (itemId: MenuItemType) => {
-    setActiveItem(itemId);
+  /**
+   * 현재 경로에 따라 activeItem 자동 결정
+   */
+  const getActiveItem = (): MenuItemType => {
+    if (pathname.includes('/profile')) {
+      return 'myInfo';
+    }
+    if (pathname.includes('/myreservation')) {
+      return 'reservationHistory';
+    }
+    if (pathname.includes('/myactivities')) {
+      return 'manageExperiences';
+    }
+    if (pathname.includes('/reservation-status')) {
+      return 'reservationStatus';
+    }
+
+    return 'reservationHistory';
   };
 
-  const handleKeyDown = (e: React.KeyboardEvent, itemId: MenuItemType) => {
+  const [activeItem, setActiveItem] = useState<MenuItemType>(getActiveItem());
+
+  const handleMenuClick = (itemId: MenuItemType, href: string) => {
+    setActiveItem(itemId);
+    router.push(href);
+  };
+
+  const handleKeyDown = (
+    e: React.KeyboardEvent,
+    itemId: MenuItemType,
+    href: string
+  ) => {
     if (e.key === 'Enter' || e.key === ' ') {
-      handleMenuClick(itemId);
+      handleMenuClick(itemId, href);
     }
   };
 
@@ -103,10 +135,10 @@ export default function SideMenu({
                   isActive ? 'bg-primary-100' : 'hover:bg-gray-50'
                 }`}
                 onClick={() => {
-                  handleMenuClick(item.id);
+                  handleMenuClick(item.id, item.href);
                 }}
                 onKeyDown={(e) => {
-                  handleKeyDown(e, item.id);
+                  handleKeyDown(e, item.id, item.href);
                 }}
               >
                 <Image

--- a/src/components/side-menu/type.ts
+++ b/src/components/side-menu/type.ts
@@ -8,12 +8,12 @@ export interface MenuItem {
   id: MenuItemType;
   label: string;
   iconPath: string;
+  href: string;
 }
 
 export interface SideMenuProps {
   size: 'large' | 'small';
   className?: string;
-  activeItem?: MenuItemType;
 }
 export interface ProfileImageProps {
   size: 'large' | 'small';


### PR DESCRIPTION
## `src/components/side-menu/index.tsx`
```tsx
const getActiveItem = (): MenuItemType => {
  if (pathname.includes('/profile')) return 'myInfo';
  if (pathname.includes('/myreservation')) return 'reservationHistory';
  if (pathname.includes('/myactivities')) return 'manageExperiences';
  if (pathname.includes('/reservation-status')) return 'reservationStatus';
  return 'reservationHistory';
};
```
1. 페이지 접속 → URL 확인 (/reservation-status)
2. getActiveItem() 실행 → 'reservationStatus' 반환
3. 해당 메뉴에 bg-primary-100 스타일 적용